### PR TITLE
Fix: runqlat_show always return EPERM

### DIFF
--- a/trace_runqlat.c
+++ b/trace_runqlat.c
@@ -460,7 +460,7 @@ static int runqlat_show(struct seq_file *m, void *ptr)
 	int i, j;
 	struct runqlat_info *info = m->private;
 
-	if (info->pid != INVALID_CPU)
+	if (info->pid == INVALID_PID)
 		return -EPERM;
 
 	local_irq_disable();


### PR DESCRIPTION
`cat /proc/trace_runqlat/runqlat` always return EPERM.
It should return EPERM only when pid is `INVALID_PID`.